### PR TITLE
chore: Run ci checks on commit to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,8 +19,6 @@ workflows:
     jobs:
       - buildtest:
           filters:
-            branches:
-              ignore: master
             tags:
               ignore: /.*/
   release:


### PR DESCRIPTION
Changed the build definition so that the CI checks are run on commit to master as well.

Relates To: #21

Signed-off-by: Richard Case <198425+richardcase@users.noreply.github.com>
