### PR TITLE
chore: Remove explicit build step from release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ workflows:
   any-commit:
     jobs:
       - buildtest:
-          filters:  
+          filters:
             tags:
               ignore: /.*/
   release:


### PR DESCRIPTION
Removed `ci` make target from release job and explicitly called
`lint` and `test`. Goreleaser will actually build.

Relates To: #21

Signed-off-by: Richard Case <198425+richardcase@users.noreply.github.com>
