### PR TITLE
Options to restart tasks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/spf13/afero v1.2.2 // indirect
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.4.0
+	github.com/stretchr/testify v1.3.0
 	golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb // indirect
 	golang.org/x/text v0.3.2 // indirect
 )

--- a/internal/ctl/connectors/restart.go
+++ b/internal/ctl/connectors/restart.go
@@ -7,11 +7,15 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 type restartConnectorsCmdParams struct {
-	ClusterURL string
-	Connectors []string
+	ClusterURL        string
+	Connectors        []string
+	ForceRestartTasks bool
+	RestartTasks      bool
+	TaskIDs           []int
 }
 
 // Command creates the the management commands
@@ -29,6 +33,15 @@ func restartConnectorsCmd() *cobra.Command {
 
 	ctl.AddCommonConnectorsFlags(restartCmd, &params.ClusterURL)
 	ctl.AddConnectorNamesFlags(restartCmd, &params.Connectors)
+
+	restartCmd.Flags().BoolVar(&params.RestartTasks, "restart-tasks", true, "Whether to restart the connector tasks")
+	_ = viper.BindPFlag("restart-tasks", restartCmd.PersistentFlags().Lookup("restart-tasks"))
+
+	restartCmd.Flags().BoolVar(&params.ForceRestartTasks, "force-restart-tasks", false, "Whether to force restart the connector tasks")
+	_ = viper.BindPFlag("force-restart-tasks", restartCmd.PersistentFlags().Lookup("force-restart-tasks"))
+
+	restartCmd.Flags().IntSliceVarP(&params.TaskIDs, "tasks", "t", []int{}, "The task ids to restart (if no ids are specified, all connectors will be restarted)")
+	_ = viper.BindPFlag("tasks", restartCmd.PersistentFlags().Lookup("tasks"))
 
 	return restartCmd
 }
@@ -48,7 +61,7 @@ func doRestartConnectors(_ *cobra.Command, params *restartConnectorsCmdParams) {
 		clusterLogger.WithError(err).Fatalln("error creating connectors manager")
 	}
 
-	err = mngr.Restart(params.Connectors)
+	err = mngr.Restart(params.Connectors, params.RestartTasks, params.ForceRestartTasks, params.TaskIDs)
 	if err != nil {
 		clusterLogger.WithError(err).Fatal("error restarting connectors")
 	}

--- a/pkg/manager/tasks.go
+++ b/pkg/manager/tasks.go
@@ -1,0 +1,50 @@
+package manager
+
+import (
+	"github.com/90poe/connectctl/pkg/client/connect"
+	"sort"
+)
+
+type Tasks []connect.TaskState
+
+// TaskPredicate is a function that performs some test on a connect.TaskState
+type TaskPredicate func(*connect.TaskState) bool
+
+// IsRunning returns true if the connector task is in a RUNNING state
+func IsRunning(task *connect.TaskState) bool {
+	return task.State == "RUNNING"
+}
+
+// IsNotRunning returns true if the connector task is not in a RUNNING state
+func IsNotRunning(task *connect.TaskState) bool {
+	return task.State != "RUNNING"
+}
+
+// ByID returns a predicate that returns true if the connector task has one of the given task IDs
+func ByID(taskIDs ...int) TaskPredicate {
+	sort.Ints(taskIDs)
+	return func(task *connect.TaskState) bool {
+		found := sort.SearchInts(taskIDs, task.ID)
+		return found < len(taskIDs) && taskIDs[found] == task.ID
+	}
+}
+
+// IDs returns a subset of the Tasks for which the predicate returns true
+func (t Tasks) Filter(predicate TaskPredicate) Tasks {
+	var found Tasks
+	for _, task := range t {
+		if predicate(&task) {
+			found = append(found, task)
+		}
+	}
+	return found
+}
+
+// IDs returns the slice of task IDs
+func (t Tasks) IDs() []int {
+	taskIDs := make([]int, len(t))
+	for i, task := range t {
+		taskIDs[i] = task.ID
+	}
+	return taskIDs
+}

--- a/pkg/manager/tasks_test.go
+++ b/pkg/manager/tasks_test.go
@@ -1,0 +1,59 @@
+package manager
+
+import (
+	"github.com/90poe/connectctl/pkg/client/connect"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestTasks_ByID_Found(t *testing.T) {
+	f := ByID(3, 2, 1)
+	assert.True(t, f(&connect.TaskState{ID: 1}))
+	assert.True(t, f(&connect.TaskState{ID: 2}))
+	assert.True(t, f(&connect.TaskState{ID: 3}))
+	assert.False(t, f(&connect.TaskState{ID: 0}))
+	assert.False(t, f(&connect.TaskState{ID: 4}))
+}
+
+func TestTasks_IsRunning(t *testing.T) {
+	f := IsRunning
+	assert.True(t, f(&connect.TaskState{State: "RUNNING"}))
+	assert.False(t, f(&connect.TaskState{State: "OTHER"}))
+}
+
+func TestTasks_IsNotRunning(t *testing.T) {
+	f := IsNotRunning
+	assert.False(t, f(&connect.TaskState{State: "RUNNING"}))
+	assert.True(t, f(&connect.TaskState{State: "OTHER"}))
+}
+
+func TestTasks_IDsEmpty(t *testing.T) {
+	var tasks Tasks
+	assert.Equal(t, []int{}, tasks.IDs())
+}
+
+func TestTasks_IDsNotEmpty(t *testing.T) {
+	assert.Equal(t, []int{1, 2, 3},
+		Tasks{
+			connect.TaskState{ID: 1},
+			connect.TaskState{ID: 2},
+			connect.TaskState{ID: 3},
+		}.IDs())
+}
+
+func TestTasks_Filter(t *testing.T) {
+	assert.Equal(t, Tasks{
+		connect.TaskState{ID: 2},
+		connect.TaskState{ID: 1},
+		connect.TaskState{ID: 0},
+	},
+		Tasks{
+			connect.TaskState{ID: -2},
+			connect.TaskState{ID: 2},
+			connect.TaskState{ID: -1},
+			connect.TaskState{ID: 1},
+			connect.TaskState{ID: 0},
+		}.Filter(func(task *connect.TaskState) bool {
+			return task.ID >= 0
+		}))
+}

--- a/pkg/manager/types.go
+++ b/pkg/manager/types.go
@@ -9,5 +9,5 @@ type ConnectorWithState struct {
 	Name           string                  `json:"name"`
 	Config         connect.ConnectorConfig `json:"config,omitempty"`
 	ConnectorState connect.ConnectorState  `json:"connectorState,omitempty"`
-	Tasks          []connect.TaskState     `json:"tasks,omitempty"`
+	Tasks          Tasks                   `json:"tasks,omitempty"`
 }


### PR DESCRIPTION
This adds extra options to the `connectctl connectors restart` command

```
connectctl connectors restart -c http://localhost:8083 -n "sink-elasticsearch-test" -restart-tasks=true -tasks 1,2,3 --force-restart-tasks=true
```

```
$ connectctl connectors restart
INFO[2019-10-02T19:19:10+01:00] connectctl, a Kafka Connect CLI              
Error: required flag(s) "cluster" not set
Usage:
  connectctl connectors restart [flags]

Flags:
  -c, --cluster string           the URL of the connect cluster to manage (required)
  -n, --connectors stringArray   The connect names to restart (if not specified all connectors will be restarted)
      --force-restart-tasks      Whether to force restart the connector tasks
  -h, --help                     help for restart
      --restart-tasks            Whether to restart the connector tasks (default true)
  -t, --tasks ints               The task ids to restart (if no ids are specified, all connectors will be restarted)

Global Flags:
      --config string     Config file (default is $HOME/.connectctl.yaml)
      --logfile string    A file to use for log output (Optional)
  -l, --loglevel string   Log level for the CLI (Optional)

required flag(s) "cluster" not set
```