### PR TITLE
fix: version.go was moved to internal

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,7 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
-      - -s -w -X github.com/90poe/connectctl/pkg/version.BuildDate={{.Date}} -X github.com/90poe/connectctl/pkg/version.GitHash={{.Commit}} -X github.com/90poe/connectctl/pkg/version.Version={{.Version}}
+      - -s -w -X github.com/90poe/connectctl/internal/version.BuildDate={{.Date}} -X github.com/90poe/connectctl/internal/version.GitHash={{.Commit}} -X github.com/90poe/connectctl/internal/version.Version={{.Version}}
     goos:
       - windows
       - darwin

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ git_commit := $(shell git describe --dirty --always)
 
 .PHONY: build
 build:
-	CGO_ENABLED=0 go build -ldflags "-X github.com/90poe/connectctl/pkg/version.GitHash=$(git_commit) -X github.com/90poe/connectctl/pkg/version.BuildDate=$(built_at)" ./cmd/connectctl
+	CGO_ENABLED=0 go build -ldflags "-X github.com/90poe/connectctl/internal/version.GitHash=$(git_commit) -X github.com/90poe/connectctl/internal/version.BuildDate=$(built_at)" ./cmd/connectctl
 
 .PHONY: install-deps
 install-deps:


### PR DESCRIPTION

Explain the **details** for making this change. What existing problem does the pull request solve?

```
make build
 ./connectctl version
INFO[2019-10-11T10:53:26+01:00] connectctl, a Kafka Connect CLI
INFO[2019-10-11T10:53:26+01:00] Version:
INFO[2019-10-11T10:53:26+01:00] Commit:
INFO[2019-10-11T10:53:26+01:00] Build Date:
INFO[2019-10-11T10:53:26+01:00] GO Version: go1.13.1
INFO[2019-10-11T10:53:26+01:00] GOOS: darwin
INFO[2019-10-11T10:53:26+01:00] GOARCH: amd64
```

Notice that the fields Version, Commit and Build Date aren't set

This PR fixes the setting of the variables.

**Test plan (required)**

```make build``` and then visual inspection via ```connectctl version```

