### PR TITLE
fix: download a known version of golang-ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,16 @@
 built_at := $(shell date +%s)
 git_commit := $(shell git describe --dirty --always)
 
+BIN:=./bin
+
+OS := $(shell uname)
+GOLANGCI_LINT_VERSION=1.18.0
+ifeq ($(OS),Darwin)
+	GOLANGCI_LINT_ARCHIVE=golangci-lint-$(GOLANGCI_LINT_VERSION)-darwin-amd64.tar.gz
+else
+	GOLANGCI_LINT_ARCHIVE=golangci-lint-$(GOLANGCI_LINT_VERSION)-linux-amd64.tar.gz
+endif
+
 .PHONY: build
 build:
 	CGO_ENABLED=0 go build -ldflags "-X github.com/90poe/connectctl/pkg/version.GitHash=$(git_commit) -X github.com/90poe/connectctl/pkg/version.BuildDate=$(built_at)" ./cmd/connectctl
@@ -22,9 +32,16 @@ release: install-deps test lint
 test:
 	@go test -v -covermode=count -coverprofile=coverage.out ./...
 
-.PHONY: lint
-lint:
-	./bin/golangci-lint run
-
 .PHONY: ci
 ci: install-deps build test lint
+
+.PHONY: lint
+lint: $(BIN)/golangci-lint/golangci-lint ## lint
+	$(BIN)/golangci-lint/golangci-lint run
+
+$(BIN)/golangci-lint/golangci-lint:
+	curl -OL https://github.com/golangci/golangci-lint/releases/download/v$(GOLANGCI_LINT_VERSION)/$(GOLANGCI_LINT_ARCHIVE)
+	mkdir -p $(BIN)/golangci-lint/
+	tar -xf $(GOLANGCI_LINT_ARCHIVE) --strip-components=1 -C $(BIN)/golangci-lint/
+	chmod +x $(BIN)/golangci-lint
+	rm -f $(GOLANGCI_LINT_ARCHIVE)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ git_commit := $(shell git describe --dirty --always)
 BIN:=./bin
 
 OS := $(shell uname)
-GOLANGCI_LINT_VERSION=1.18.0
+GOLANGCI_LINT_VERSION?=1.19.1
 ifeq ($(OS),Darwin)
 	GOLANGCI_LINT_ARCHIVE=golangci-lint-$(GOLANGCI_LINT_VERSION)-darwin-amd64.tar.gz
 else
@@ -15,17 +15,12 @@ endif
 build:
 	CGO_ENABLED=0 go build -ldflags "-X github.com/90poe/connectctl/pkg/version.GitHash=$(git_commit) -X github.com/90poe/connectctl/pkg/version.BuildDate=$(built_at)" ./cmd/connectctl
 
-.PHONY: install-deps
-install-deps:
-	go mod download
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.19.1
-
 .PHONY: local-release
 local-release:
 	goreleaser --snapshot --skip-publish --rm-dist
 
 .PHONY: release
-release: install-deps test lint
+release: test lint
 	curl -sL https://git.io/goreleaser | bash
 
 .PHONY: test
@@ -33,7 +28,7 @@ test:
 	@go test -v -covermode=count -coverprofile=coverage.out ./...
 
 .PHONY: ci
-ci: install-deps build test lint
+ci: build test lint
 
 .PHONY: lint
 lint: $(BIN)/golangci-lint/golangci-lint ## lint


### PR DESCRIPTION
This PR closes #18 and installs the golang-ci app. 
Calling `make lint` twice will only download the file once e.g. 

```
make lint
curl -OL https://github.com/golangci/golangci-lint/releases/download/v1.18.0/golangci-lint-1.18.0-darwin-amd64.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   631    0   631    0     0   2622      0 --:--:-- --:--:-- --:--:--  2618
100 7950k  100 7950k    0     0  3193k      0  0:00:02  0:00:02 --:--:-- 5156k
mkdir -p ./bin/golangci-lint/
tar -xf golangci-lint-1.18.0-darwin-amd64.tar.gz --strip-components=1 -C ./bin/golangci-lint/
chmod +x ./bin/golangci-lint
rm -f golangci-lint-1.18.0-darwin-amd64.tar.gz
./bin/golangci-lint/golangci-lint run
➜  connectctl git:(install-golang-ci) ✗ make lint
./bin/golangci-lint/golangci-lint run
```


**Test plan (required)**

Run `make lint` to download default version
Run `GOLANGCI_LINT_VERSION=1.1 make lint` to download a specified version
