### PR TITLE
Feat/readyness check whilst managing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8 // indirect
 	github.com/go-openapi/errors v0.19.2 // indirect
 	github.com/go-openapi/strfmt v0.19.0 // indirect
+	github.com/heptiolabs/healthcheck v0.0.0-20180807145615-6ff867650f40
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
 	github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63 // indirect
 	github.com/mattn/go-runewidth v0.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,7 @@ github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
+github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -62,6 +63,8 @@ github.com/grpc-ecosystem/grpc-gateway v1.9.0 h1:bM6ZAFZmc/wPFaRDi0d5L7hGEZEx/2u
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/heptiolabs/healthcheck v0.0.0-20180807145615-6ff867650f40 h1:GT4RsKmHh1uZyhmTkWJTDALRjSHYQp6FRKrotf0zhAs=
+github.com/heptiolabs/healthcheck v0.0.0-20180807145615-6ff867650f40/go.mod h1:NtmN9h8vrTveVQRLHcX2HQ5wIPBDCsZ351TGbZWgg38=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jedib0t/go-pretty v4.3.0+incompatible h1:CGs8AVhEKg/n9YbUenWmNStRW2PHJzaeDodcfvRAbIo=
@@ -85,6 +88,7 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63 h1:nTT4s92Dgz2HlrB
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -101,12 +105,16 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
+github.com/prometheus/client_golang v0.9.3 h1:9iH4JKXLzFbOAdtqv/a+j8aewx2Y8lAjAydhbaScPF8=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
+github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 h1:S/YWwWx/RA8rT8tKFRuGUZhuA90OyIBpPCXkcbwU8DE=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
+github.com/prometheus/common v0.4.0 h1:7etb9YClo3a6HjLzfl6rIQaU+FDfi0VSX39io3aQ+DM=
 github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
+github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084 h1:sofwID9zm4tzrgykg80hfFph1mryUeLRsUfoocVVmRY=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=

--- a/internal/ctl/connectors/manage.go
+++ b/internal/ctl/connectors/manage.go
@@ -2,7 +2,6 @@ package connectors
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/90poe/connectctl/internal/ctl"
@@ -53,7 +52,7 @@ if you specify --once then it will sync once and then exit.`,
 	ctl.AddCommonConnectorsFlags(manageCmd, &params.ClusterURL)
 	ctl.AddDefinitionFilesFlags(manageCmd, &params.Files, &params.Directory, &params.EnvVar)
 
-	manageCmd.Flags().DurationVarP(&params.SyncPeriod, "sync-period", "s", params.SyncPeriod, fmt.Sprintf("How often to sync with the connect cluster. Defaults to %s", params.SyncPeriod))
+	manageCmd.Flags().DurationVarP(&params.SyncPeriod, "sync-period", "s", params.SyncPeriod, "How often to sync with the connect cluster")
 	_ = viper.BindPFlag("sync-period", manageCmd.PersistentFlags().Lookup("sync-period"))
 
 	manageCmd.Flags().BoolVarP(&params.AllowPurge, "allow-purge", "", false, "If true it will manage all connectors in a cluster. If connectors exist in the cluster that aren't specified in --files then the connectors will be deleted")
@@ -65,10 +64,10 @@ if you specify --once then it will sync once and then exit.`,
 	manageCmd.Flags().BoolVar(&params.RunOnce, "once", false, "if supplied sync will run once and command will exit")
 	_ = viper.BindPFlag("once", manageCmd.PersistentFlags().Lookup("once"))
 
-	manageCmd.Flags().BoolVar(&params.EnableHealthCheck, "enable-healthcheck", false, "if supplied a healthcheck via http will be enabled")
-	_ = viper.BindPFlag("enable-healthcheck", manageCmd.PersistentFlags().Lookup("enable-healthcheck"))
+	manageCmd.Flags().BoolVar(&params.EnableHealthCheck, "healthcheck-enable", false, "if supplied a healthcheck via http will be enabled")
+	_ = viper.BindPFlag("healthcheck-enable", manageCmd.PersistentFlags().Lookup("healthcheck-enable"))
 
-	manageCmd.Flags().StringVar(&params.HealthCheckAddress, "healthcheck-address", params.HealthCheckAddress, fmt.Sprintf("if enabled the healthchecks ('/live' and '/ready') will be available from this address. Defaults to %s", params.HealthCheckAddress))
+	manageCmd.Flags().StringVar(&params.HealthCheckAddress, "healthcheck-address", params.HealthCheckAddress, "if enabled the healthchecks ('/live' and '/ready') will be available from this address")
 	_ = viper.BindPFlag("healthcheck-address", manageCmd.PersistentFlags().Lookup("healthcheck-address"))
 
 	return manageCmd

--- a/internal/healthcheck/healthcheck.go
+++ b/internal/healthcheck/healthcheck.go
@@ -1,0 +1,55 @@
+package healthcheck
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/heptiolabs/healthcheck"
+)
+
+type health struct {
+	healthcheck.Handler
+	server *http.Server
+}
+
+// healthCheckable constrains the type accepted to the registerHealthChecks to
+// instances that implement a Readiness and a Liveness probe
+type healthCheckable interface {
+	ReadinessCheck() (string, func() error)
+	LivenessCheck() (string, func() error)
+}
+
+// New initiates the healthchecks as an HTTP server
+func New(healthCheckables ...healthCheckable) *health { // nolint
+	h := &health{Handler: healthcheck.NewHandler()}
+	h.Append(healthCheckables...)
+	return h
+}
+
+// Append will register the healthchecks
+func (h *health) Append(healthCheckables ...healthCheckable) {
+	for _, check := range healthCheckables {
+		key, f := check.LivenessCheck()
+		h.AddLivenessCheck(key, f)
+
+		key, f = check.ReadinessCheck()
+		h.AddReadinessCheck(key, f)
+	}
+}
+
+// Start binds to the given address or returns an error
+// Will block so start in a go routine.
+func (h *health) Start(address string) error {
+	h.server = &http.Server{Addr: address, Handler: h.Handler}
+
+	if err := h.server.ListenAndServe(); err != http.ErrServerClosed {
+		return err
+	}
+
+	return nil
+}
+
+// Shutdown will close the underlying http server
+func (h *health) Shutdown(ctx context.Context) error {
+	return h.server.Shutdown(ctx)
+}

--- a/pkg/manager/config.go
+++ b/pkg/manager/config.go
@@ -4,7 +4,7 @@ import (
 	"time"
 )
 
-// Config represent the connect manager configuration
+// Config represents the connect manager configuration
 type Config struct {
 	ClusterURL  string
 	SyncPeriod  time.Duration

--- a/pkg/manager/manage.go
+++ b/pkg/manager/manage.go
@@ -20,7 +20,6 @@ func (c *ConnectorManager) Manage(source ConnectorSource, stopCH <-chan struct{}
 	syncChannel := time.NewTicker(c.config.SyncPeriod).C
 	for {
 		select {
-
 		case <-syncChannel:
 			err := c.Sync(source)
 			if err != nil {
@@ -47,7 +46,6 @@ func (c *ConnectorManager) Sync(source ConnectorSource) error {
 	if err = c.reconcileConnectors(connectors); err != nil {
 		return errors.Wrap(err, "synchronising connectors")
 	}
-
 	return nil
 }
 

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -50,7 +50,6 @@ const (
 // ReadinessCheck checks if we have been able to start syncing with kafka-connect
 func (c *ConnectorManager) ReadinessCheck() (string, func() error) {
 	return "connectctl-readiness-check", func() error {
-
 		switch c.readinessState {
 		case okState:
 			return nil
@@ -63,7 +62,7 @@ func (c *ConnectorManager) ReadinessCheck() (string, func() error) {
 }
 
 // LivenessCheck checks if the the kafka-connect instance is running.
-// The timeout of 2 seconds is arbitary.
+// The timeout of 2 seconds is arbitrary.
 func (c *ConnectorManager) LivenessCheck() (string, func() error) {
 	return "connectctl-liveness-check-kafka-connect-instance",
 		healthcheck.HTTPGetCheck(c.config.ClusterURL, time.Second*2)

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -34,3 +34,11 @@ func NewConnectorsManager(config *Config) (*ConnectorManager, error) {
 		logger: log.WithField("cluster", config.ClusterURL),
 	}, nil
 }
+
+func (c *ConnectorManager) ReadinessCheck() (string, func() error) {
+	return "connectctl-readiness-check", func() error { return nil }
+}
+
+func (c *ConnectorManager) LivenessCheck() (string, func() error) {
+	return "connectctl-liveness-check", func() error { return nil }
+}

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -75,12 +75,14 @@ func EnvVarValue(env string) func() ([]connect.Connector, error) {
 
 // StdIn returns the connectors piped via stdin or an error
 func StdIn(in io.Reader) func() ([]connect.Connector, error) {
-	return func() ([]connect.Connector, error) {
-		data, err := ioutil.ReadAll(in)
+	// read the input as io.Reader isn't re-readable
+	data, err := ioutil.ReadAll(in)
 
+	return func() ([]connect.Connector, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "error reading from StdIn")
 		}
+
 		return processBytes(data)
 	}
 }


### PR DESCRIPTION
This PR adds an optional ability to expose a healthcheck whilst managing a kafka connect instance.

The healthchecks are delmontes so always return 200 / Ok.

The cli displays the following additional arguments - 

```
 ./connectctl connectors manage -h
...
      --healthcheck-address string   if enabled the healthchecks ('/live' and '/ready') will be available from this address (default ":9000")
      --healthcheck-enable           if supplied a healthcheck via http will be enabled
...
```