### PR TITLE
feature : additional methods for add and manage to get their connector configs

### DIFF
--- a/internal/ctl/connectors/add.go
+++ b/internal/ctl/connectors/add.go
@@ -4,6 +4,7 @@ import (
 	"github.com/90poe/connectctl/internal/ctl"
 	"github.com/90poe/connectctl/internal/version"
 	"github.com/90poe/connectctl/pkg/manager"
+	"github.com/90poe/connectctl/pkg/sources"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -13,6 +14,7 @@ type addConnectorsCmdParams struct {
 	ClusterURL string
 	Files      []string
 	Directory  string
+	EnvVar     string
 }
 
 func addConnectorCmd() *cobra.Command {
@@ -28,7 +30,7 @@ func addConnectorCmd() *cobra.Command {
 	}
 
 	ctl.AddCommonConnectorsFlags(addCmd, &params.ClusterURL)
-	ctl.AddDefinitionFilesFlags(addCmd, &params.Files, &params.Directory)
+	ctl.AddDefinitionFilesFlags(addCmd, &params.Files, &params.Directory, &params.EnvVar)
 
 	return addCmd
 }
@@ -45,10 +47,13 @@ func doAddConnectors(_ *cobra.Command, params *addConnectorsCmdParams) {
 
 	var source manager.ConnectorSource
 	if params.Files != nil {
-		source = filesSource(&params.Files)
+		source = sources.Files(params.Files)
 	}
 	if params.Directory != "" {
-		source = directorySource(&params.Directory)
+		source = sources.Directory(params.Directory)
+	}
+	if params.EnvVar != "" {
+		source = sources.EnvVarValue(params.EnvVar)
 	}
 
 	connectors, err := source()

--- a/internal/ctl/connectors/add.go
+++ b/internal/ctl/connectors/add.go
@@ -47,17 +47,18 @@ func doAddConnectors(cmd *cobra.Command, params *addConnectorsCmdParams) {
 
 	var source manager.ConnectorSource
 
-	if params.Files != nil {
+	switch {
+	case params.Files != nil:
 		if len(params.Files) == 1 && params.Files[0] == "-" {
 			source = sources.StdIn(cmd.InOrStdin())
 		} else {
 			source = sources.Files(params.Files)
 		}
-	} else if params.Directory != "" {
+	case params.Directory != "":
 		source = sources.Directory(params.Directory)
-	} else if params.EnvVar != "" {
+	case params.EnvVar != "":
 		source = sources.EnvVarValue(params.EnvVar)
-	} else {
+	default:
 		clusterLogger.Fatalln("error finding connector definitions from parameters")
 	}
 

--- a/internal/ctl/connectors/manage.go
+++ b/internal/ctl/connectors/manage.go
@@ -60,7 +60,7 @@ if you specify --once then it will sync once and then exit.`,
 	return manageCmd
 }
 
-func doManageConnectors(_ *cobra.Command, params *manageConnectorsCmdParams) {
+func doManageConnectors(cmd *cobra.Command, params *manageConnectorsCmdParams) {
 	clusterLogger := log.WithField("cluster", params.ClusterURL)
 	clusterLogger.Debug("executing manage connectors command")
 

--- a/internal/ctl/connectors/manage.go
+++ b/internal/ctl/connectors/manage.go
@@ -71,17 +71,18 @@ func doManageConnectors(cmd *cobra.Command, params *manageConnectorsCmdParams) {
 
 	var source manager.ConnectorSource
 
-	if params.Files != nil {
+	switch {
+	case params.Files != nil:
 		if len(params.Files) == 1 && params.Files[0] == "-" {
 			source = sources.StdIn(cmd.InOrStdin())
 		} else {
 			source = sources.Files(params.Files)
 		}
-	} else if params.Directory != "" {
+	case params.Directory != "":
 		source = sources.Directory(params.Directory)
-	} else if params.EnvVar != "" {
+	case params.EnvVar != "":
 		source = sources.EnvVarValue(params.EnvVar)
-	} else {
+	default:
 		clusterLogger.Fatalln("error finding connector definitions from parameters")
 	}
 
@@ -115,7 +116,6 @@ func doManageConnectors(cmd *cobra.Command, params *manageConnectorsCmdParams) {
 }
 
 func checkConfig(params *manageConnectorsCmdParams) error {
-
 	paramsSet := 0
 
 	if len(params.Files) != 0 {

--- a/internal/ctl/connectors/manage.go
+++ b/internal/ctl/connectors/manage.go
@@ -70,14 +70,19 @@ func doManageConnectors(cmd *cobra.Command, params *manageConnectorsCmdParams) {
 	}
 
 	var source manager.ConnectorSource
+
 	if params.Files != nil {
-		source = sources.Files(params.Files)
-	}
-	if params.Directory != "" {
+		if len(params.Files) == 1 && params.Files[0] == "-" {
+			source = sources.StdIn(cmd.InOrStdin())
+		} else {
+			source = sources.Files(params.Files)
+		}
+	} else if params.Directory != "" {
 		source = sources.Directory(params.Directory)
-	}
-	if params.EnvVar != "" {
+	} else if params.EnvVar != "" {
 		source = sources.EnvVarValue(params.EnvVar)
+	} else {
+		clusterLogger.Fatalln("error finding connector definitions from parameters")
 	}
 
 	config := &manager.Config{

--- a/internal/ctl/flags.go
+++ b/internal/ctl/flags.go
@@ -16,12 +16,16 @@ func AddOutputFlags(cmd *cobra.Command, output *string) {
 	_ = viper.BindPFlag("output", cmd.PersistentFlags().Lookup("output"))
 }
 
-func AddDefinitionFilesFlags(cmd *cobra.Command, files *[]string, directory *string) {
-	cmd.Flags().StringArrayVarP(files, "files", "f", []string{}, "The connector definitions files (Required if --directory not specified)")
+func AddDefinitionFilesFlags(cmd *cobra.Command, files *[]string, directory *string, env *string) {
+	cmd.Flags().StringArrayVarP(files, "files", "f", []string{}, "The connector definitions files (Required if --directory or --env-var not specified)")
 	_ = viper.BindPFlag("files", cmd.PersistentFlags().Lookup("files"))
 
-	cmd.Flags().StringVarP(directory, "directory", "d", "", "The directory containing the connector definitions files (Required if --files not specified)")
+	cmd.Flags().StringVarP(directory, "directory", "d", "", "The directory containing the connector definitions files (Required if --file or --env-vars not specified)")
 	_ = viper.BindPFlag("directory", cmd.PersistentFlags().Lookup("directory"))
+
+	cmd.Flags().StringVarP(env, "env-var", "e", "", "An environmental variable whose value is a singular or array of connectors serialised as JSON (Required if --files or --directory not specified)")
+	_ = viper.BindPFlag("env-var", cmd.PersistentFlags().Lookup("env-var"))
+
 }
 
 func AddConnectorNamesFlags(cmd *cobra.Command, names *[]string) {

--- a/internal/ctl/flags.go
+++ b/internal/ctl/flags.go
@@ -25,7 +25,6 @@ func AddDefinitionFilesFlags(cmd *cobra.Command, files *[]string, directory *str
 
 	cmd.Flags().StringVarP(env, "env-var", "e", "", "An environmental variable whose value is a singular or array of connectors serialised as JSON (Required if --files or --directory not specified)")
 	_ = viper.BindPFlag("env-var", cmd.PersistentFlags().Lookup("env-var"))
-
 }
 
 func AddConnectorNamesFlags(cmd *cobra.Command, names *[]string) {

--- a/pkg/client/connect/connectors.go
+++ b/pkg/client/connect/connectors.go
@@ -22,7 +22,7 @@ type Connector struct {
 // and return true or false if they are equal.
 //
 // Note: tasks are ignored in the comparison
-func (c *Connector) ConfigEqual(other *Connector) bool {
+func (c *Connector) ConfigEqual(other Connector) bool {
 	if c.Name != other.Name {
 		return false
 	}
@@ -85,7 +85,7 @@ type TaskState struct {
 // Passing an object that already contains Tasks produces an error.
 //
 // See: http://docs.confluent.io/current/connect/userguide.html#post--connectors
-func (c *Client) CreateConnector(conn *Connector) (*http.Response, error) {
+func (c *Client) CreateConnector(conn Connector) (*http.Response, error) {
 	if len(conn.Tasks) != 0 {
 		return nil, errors.New("cannot create Connector with existing Tasks")
 	}

--- a/pkg/manager/crud.go
+++ b/pkg/manager/crud.go
@@ -63,7 +63,7 @@ func (c *ConnectorManager) ListConnectors() ([]string, error) {
 }
 
 // Add will add connectors to a cluster
-func (c *ConnectorManager) Add(connectors []*connect.Connector) error {
+func (c *ConnectorManager) Add(connectors []connect.Connector) error {
 	c.logger.Debug("adding connectors")
 
 	for _, connector := range connectors {

--- a/pkg/manager/manage.go
+++ b/pkg/manager/manage.go
@@ -43,7 +43,7 @@ func (c *ConnectorManager) Sync(source ConnectorSource) error {
 	return nil
 }
 
-func (c *ConnectorManager) reconcileConnectors(connectors []*connect.Connector) error {
+func (c *ConnectorManager) reconcileConnectors(connectors []connect.Connector) error {
 	c.logger.Debug("reconciling connectors")
 
 	for _, connector := range connectors {
@@ -71,7 +71,7 @@ func (c *ConnectorManager) reconcileConnectors(connectors []*connect.Connector) 
 	return nil
 }
 
-func (c *ConnectorManager) autoRestart(connectors []*connect.Connector) error {
+func (c *ConnectorManager) autoRestart(connectors []connect.Connector) error {
 	c.logger.Debug("auto restarting connectors")
 
 	for _, connector := range connectors {
@@ -120,7 +120,7 @@ func (c *ConnectorManager) autoRestart(connectors []*connect.Connector) error {
 	return nil
 }
 
-func (c *ConnectorManager) checkAndDeleteUnmanaged(connectors []*connect.Connector) error {
+func (c *ConnectorManager) checkAndDeleteUnmanaged(connectors []connect.Connector) error {
 	c.logger.Debug("purging any unmanaged connectors from cluster")
 
 	existing, resp, err := c.client.ListConnectors()
@@ -157,7 +157,7 @@ func (c *ConnectorManager) deleteUnmanaged(unmanagedConnectors []string) error {
 	return nil
 }
 
-func (c *ConnectorManager) reconcileConnector(connector *connect.Connector) error {
+func (c *ConnectorManager) reconcileConnector(connector connect.Connector) error {
 	connectLogger := c.logger.WithField("connector", connector.Name)
 	connectLogger.Debug("reconciling connector")
 	defer connectLogger.Debug("reconciled connector")
@@ -181,7 +181,7 @@ func (c *ConnectorManager) reconcileConnector(connector *connect.Connector) erro
 	return nil
 }
 
-func (c *ConnectorManager) handleExistingConnector(connector *connect.Connector, existingConnector *connect.Connector, logger *log.Entry) error {
+func (c *ConnectorManager) handleExistingConnector(connector connect.Connector, existingConnector *connect.Connector, logger *log.Entry) error {
 	logger.Debug("connector already exists")
 
 	if existingConnector.ConfigEqual(connector) {
@@ -202,10 +202,10 @@ func (c *ConnectorManager) handleExistingConnector(connector *connect.Connector,
 	return nil
 }
 
-func (c *ConnectorManager) handleNewConnector(connector *connect.Connector, logger *log.Entry) error {
+func (c *ConnectorManager) handleNewConnector(connector connect.Connector, logger *log.Entry) error {
 	logger.Info("connector doesn't exist, creating")
 
-	err := c.Add([]*connect.Connector{connector})
+	err := c.Add([]connect.Connector{connector})
 
 	if err != nil {
 		logger.WithError(err).Debug("error creating connector")
@@ -216,7 +216,7 @@ func (c *ConnectorManager) handleNewConnector(connector *connect.Connector, logg
 	return nil
 }
 
-func containsConnector(connectorName string, connectors []*connect.Connector) bool {
+func containsConnector(connectorName string, connectors []connect.Connector) bool {
 	for _, c := range connectors {
 		if c.Name == connectorName {
 			return true

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ConnectorSource will return a slice of the desired connector configuration
-type ConnectorSource func() ([]*connect.Connector, error)
+type ConnectorSource func() ([]connect.Connector, error)
 
 // ConnectorManager manages connectors in a Kafka Connect cluster
 type ConnectorManager struct {

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -1,0 +1,97 @@
+package sources
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/90poe/connectctl/pkg/client/connect"
+)
+
+func Files(files []string) func() ([]connect.Connector, error) {
+	return func() ([]connect.Connector, error) {
+		connectors := make([]connect.Connector, len(files))
+
+		for index, file := range files {
+			bytes, err := ioutil.ReadFile(file)
+			if err != nil {
+				return nil, errors.Wrapf(err, "reading connector json %s", file)
+			}
+
+			c, err := newConnectorFromBytes(bytes)
+
+			if err != nil {
+				return nil, errors.Wrap(err, "unmarshalling connector from bytes")
+			}
+
+			connectors[index] = c
+		}
+
+		return connectors, nil
+	}
+}
+
+func Directory(dir string) func() ([]connect.Connector, error) {
+	return func() ([]connect.Connector, error) {
+		var files []string
+
+		err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+			if filepath.Ext(path) == ".json" {
+				files = append(files, path)
+			}
+			return nil
+		})
+		if err != nil {
+			return nil, errors.Wrapf(err, "list connector files in directory %s", dir)
+		}
+
+		return Files(files)()
+	}
+}
+
+func EnvVarValue(env string) func() ([]connect.Connector, error) {
+
+	return func() ([]connect.Connector, error) {
+		value, ok := os.LookupEnv(env)
+
+		if !ok {
+			return nil, fmt.Errorf("error resolving env var : %s", env)
+		}
+
+		value = strings.TrimSpace(value)
+
+		if strings.HasPrefix(value, "[") {
+
+			c, err := newConnectorsFromBytes([]byte(value))
+			if err != nil {
+				return nil, errors.Wrap(err, "unmarshalling connector from bytes")
+			}
+
+			return c, nil
+		}
+
+		c, err := newConnectorFromBytes([]byte(value))
+		if err != nil {
+			return nil, errors.Wrap(err, "unmarshalling connector from bytes")
+		}
+
+		return []connect.Connector{c}, nil
+	}
+}
+
+func newConnectorFromBytes(bytes []byte) (connect.Connector, error) {
+	c := connect.Connector{}
+	err := json.Unmarshal(bytes, &c)
+	return c, err
+}
+
+func newConnectorsFromBytes(bytes []byte) ([]connect.Connector, error) {
+	c := []connect.Connector{}
+	err := json.Unmarshal(bytes, &c)
+	return c, err
+}

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -57,7 +57,6 @@ func Directory(dir string) func() ([]connect.Connector, error) {
 }
 
 func EnvVarValue(env string) func() ([]connect.Connector, error) {
-
 	return func() ([]connect.Connector, error) {
 		value, ok := os.LookupEnv(env)
 
@@ -71,9 +70,7 @@ func EnvVarValue(env string) func() ([]connect.Connector, error) {
 }
 
 func StdIn(in io.Reader) func() ([]connect.Connector, error) {
-
 	return func() ([]connect.Connector, error) {
-
 		data, err := ioutil.ReadAll(in)
 
 		if err != nil {
@@ -84,7 +81,6 @@ func StdIn(in io.Reader) func() ([]connect.Connector, error) {
 }
 
 func processBytes(data []byte) ([]connect.Connector, error) {
-
 	if bytes.HasPrefix(data, []byte("[")) { // REVIEW : is there a better test for a JSON array?
 		c, err := newConnectorsFromBytes(data)
 		if err != nil {

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -85,7 +85,7 @@ func StdIn(in io.Reader) func() ([]connect.Connector, error) {
 
 func processBytes(data []byte) ([]connect.Connector, error) {
 
-	if bytes.HasPrefix(data, []byte("[")) { // REVIEW : is there a better test for an array?
+	if bytes.HasPrefix(data, []byte("[")) { // REVIEW : is there a better test for a JSON array?
 		c, err := newConnectorsFromBytes(data)
 		if err != nil {
 			return nil, errors.Wrap(err, "error unmarshalling connectors from bytes")

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -15,6 +15,7 @@ import (
 	"github.com/90poe/connectctl/pkg/client/connect"
 )
 
+// Files returns the aggregrated connectors loaded from a set of filepaths or an error
 func Files(files []string) func() ([]connect.Connector, error) {
 	return func() ([]connect.Connector, error) {
 		connectors := make([]connect.Connector, len(files))
@@ -38,6 +39,8 @@ func Files(files []string) func() ([]connect.Connector, error) {
 	}
 }
 
+// Directory returns the aggregrated connectors loaded from a directory and its children or an error
+// Note - Files need to end with .json.
 func Directory(dir string) func() ([]connect.Connector, error) {
 	return func() ([]connect.Connector, error) {
 		var files []string
@@ -56,6 +59,7 @@ func Directory(dir string) func() ([]connect.Connector, error) {
 	}
 }
 
+// EnvVarValue returns the connectors loaded from an environmental variable or an error
 func EnvVarValue(env string) func() ([]connect.Connector, error) {
 	return func() ([]connect.Connector, error) {
 		value, ok := os.LookupEnv(env)
@@ -69,6 +73,7 @@ func EnvVarValue(env string) func() ([]connect.Connector, error) {
 	}
 }
 
+// StdIn returns the connectors piped via stdin or an error
 func StdIn(in io.Reader) func() ([]connect.Connector, error) {
 	return func() ([]connect.Connector, error) {
 		data, err := ioutil.ReadAll(in)

--- a/pkg/sources/sources_test.go
+++ b/pkg/sources/sources_test.go
@@ -1,0 +1,76 @@
+package sources
+
+import (
+	"os"
+	"strings"
+
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_StdIn(t *testing.T) {
+
+	testCases := []struct {
+		input  string
+		hasErr bool
+		count  int
+	}{
+		{input: "[{},{}]", count: 2},
+		{input: "[]", count: 0},
+		{input: "", count: 0, hasErr: true},
+		{input: "{}", count: 1},
+		{input: "{", count: 0, hasErr: true},
+	}
+
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.input, func(t *testing.T) {
+
+			r := strings.NewReader(tc.input)
+			f := StdIn(r)
+			c, err := f()
+
+			if tc.hasErr {
+				require.NotNil(t, err)
+			} else {
+				require.Nil(t, err)
+			}
+			require.Equal(t, len(c), tc.count)
+
+		})
+	}
+}
+
+func Test_EnvVarValue(t *testing.T) {
+
+	testCases := []struct {
+		name   string
+		input  string
+		hasErr bool
+		count  int
+	}{
+		{name: "one", input: " [{},{}]", count: 2},
+		{name: "two", input: "[]", count: 0},
+		{name: "three", input: "", count: 0, hasErr: true},
+		{name: "four", input: "{  }", count: 1},
+		{name: "five", input: "{", count: 0, hasErr: true},
+	}
+
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.name, func(t *testing.T) {
+
+			os.Setenv(tc.name, tc.input)
+			c, err := EnvVarValue(tc.name)()
+
+			if tc.hasErr {
+				require.NotNil(t, err)
+			} else {
+				require.Nil(t, err)
+			}
+			require.Equal(t, len(c), tc.count)
+
+		})
+	}
+}


### PR DESCRIPTION
This PR add an ability to pipe connector configs from std in via 

```
cat examples/connector1.json | connectctl connectors add -f -
```
and also by an env var

```
export CONNECTORS={...}
connectctl connectors add -e CONNECTORS
```

I've extracted the sources code to their own package and added tests and tried to keep the ctl package as tidy as I can. 

The only other change of note is to remove the pointers from connect.Connectors as there were a lot of pointer gymnastics.

closes #20 
