### PR TITLE
feat: add a `restart connector/task` policy

### DIFF
--- a/internal/ctl/connectors/manage.go
+++ b/internal/ctl/connectors/manage.go
@@ -61,13 +61,13 @@ if you specify --once then it will sync once and then exit.`,
 	ctl.AddCommonConnectorsFlags(manageCmd, &params.ClusterURL)
 	ctl.AddDefinitionFilesFlags(manageCmd, &params.Files, &params.Directory, &params.EnvVar)
 
-	manageCmd.Flags().DurationVarP(&params.SyncPeriod, "sync-period", "s", params.SyncPeriod, "How often to sync with the connect cluster")
+	manageCmd.Flags().DurationVarP(&params.SyncPeriod, "sync-period", "s", params.SyncPeriod, "how often to sync with the connect cluster")
 	_ = viper.BindPFlag("sync-period", manageCmd.PersistentFlags().Lookup("sync-period"))
 
-	manageCmd.Flags().BoolVarP(&params.AllowPurge, "allow-purge", "", false, "If true it will manage all connectors in a cluster. If connectors exist in the cluster that aren't specified in --files then the connectors will be deleted")
+	manageCmd.Flags().BoolVarP(&params.AllowPurge, "allow-purge", "", false, "if set connectctl will manage all connectors in a cluster. If connectors exist in the cluster that aren't specified in --files then the connectors will be deleted")
 	_ = viper.BindPFlag("allow-purge", manageCmd.PersistentFlags().Lookup("allow-purge"))
 
-	manageCmd.Flags().BoolVar(&params.AutoRestart, "auto-restart", false, "if supplied tasks that are failed with automatically be restarted")
+	manageCmd.Flags().BoolVar(&params.AutoRestart, "auto-restart", false, "if set connectors and tasks that are failed with automatically be restarted")
 	_ = viper.BindPFlag("auto-restart", manageCmd.PersistentFlags().Lookup("auto-restart"))
 
 	manageCmd.Flags().BoolVar(&params.RunOnce, "once", false, "if supplied sync will run once and command will exit")

--- a/pkg/manager/config.go
+++ b/pkg/manager/config.go
@@ -12,4 +12,23 @@ type Config struct {
 	AutoRestart bool          `json:"auto_restart"`
 
 	Version string `json:"version"`
+
+	RestartPolicy *RestartPolicy `json:"restart_policy"`
+}
+
+// RestartPolicy lists each connectors maximum restart policy
+// If a policy does not exist for a connector the connector ir task will be restarted once.
+// If a connector or task is restarted the count of failed attempts is reset.
+// If the maximum number of unsuccessful restarts is reached the manager will
+// return and connectctl will stop.
+type RestartPolicy struct {
+	Connectors map[string]Policy `json:"connectors"`
+}
+
+// Policy contains a collection of values to be managed
+type Policy struct {
+	MaxConnectorRestarts   int           `json:"max_connector_restarts"`
+	ConnectorRestartPeriod time.Duration `json:"connector_restart_period"`
+	MaxTaskRestarts        int           `json:"max_task_restarts"`
+	TaskRestartPeriod      time.Duration `json:"task_restart_period"`
 }

--- a/pkg/manager/config.go
+++ b/pkg/manager/config.go
@@ -17,10 +17,10 @@ type Config struct {
 }
 
 // RestartPolicy lists each connectors maximum restart policy
-// If a policy does not exist for a connector the connector ir task will be restarted once.
+// If AutoRestart == true
+// If a policy does not exist for a connector the connector or task will be restarted once.
 // If a connector or task is restarted the count of failed attempts is reset.
-// If the maximum number of unsuccessful restarts is reached the manager will
-// return and connectctl will stop.
+// If the number of unsuccessful restarts is reached the manager will return and connectctl will stop.
 type RestartPolicy struct {
 	Connectors map[string]Policy `json:"connectors"`
 }

--- a/pkg/manager/manage.go
+++ b/pkg/manager/manage.go
@@ -42,8 +42,8 @@ func (c *ConnectorManager) Sync(source ConnectorSource) error {
 	}
 
 	// creating a runtime restart policy here, overriding with the supplied one (if any)
-	// ensuring that we have a policy defined for each connector we are manging here
-	// dramatically simplifies all of the management and restart code
+	// Ensuring that we have a policy defined for each connector we are manging here
+	// dramatically simplifies the management and restart code
 	policy := runtimePolicyFromConnectors(connectors, c.config.RestartPolicy)
 
 	if err = c.reconcileConnectors(connectors, policy); err != nil {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -12,6 +12,10 @@ import (
 // ConnectorSource will return a slice of the desired connector configuration
 type ConnectorSource func() ([]connect.Connector, error)
 
+const (
+	defaultRestartPeriod = time.Second * 10
+)
+
 type client interface {
 	CreateConnector(conn connect.Connector) (*http.Response, error)
 	ListConnectors() ([]string, *http.Response, error)

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -12,10 +12,6 @@ import (
 // ConnectorSource will return a slice of the desired connector configuration
 type ConnectorSource func() ([]connect.Connector, error)
 
-const (
-	defaultRestartPeriod = time.Second * 10
-)
-
 type client interface {
 	CreateConnector(conn connect.Connector) (*http.Response, error)
 	ListConnectors() ([]string, *http.Response, error)

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -134,7 +134,7 @@ func Test_Manage_ConnectorRunning_FailedTasksAreRestarted(t *testing.T) {
 
 	err = cm.Sync(source)
 	require.NotNil(t, err)
-	require.Equal(t, 1, mock.RestartConnectorTaskCallCount())
+	require.Equal(t, 2, mock.RestartConnectorTaskCallCount())
 }
 
 func Test_Manage_ConnectorFailed_IsRestarted(t *testing.T) {

--- a/pkg/manager/restart_policy.go
+++ b/pkg/manager/restart_policy.go
@@ -1,0 +1,52 @@
+package manager
+
+import (
+	"time"
+
+	"github.com/90poe/connectctl/pkg/client/connect"
+)
+
+type runtimeRestartPolicy map[string]Policy
+
+const (
+	// period to use between restart attempts
+	// 10 seconds chosen at random
+	defaultRestartPeriod = time.Second * 10
+)
+
+func runtimePolicyFromConnectors(connectors []connect.Connector, overrides *RestartPolicy) runtimeRestartPolicy {
+	// create dynamic restart policy here, overriding with any supplied values (if any)
+	policy := runtimeRestartPolicy{}
+
+	for _, c := range connectors {
+		policy[c.Name] = Policy{
+			MaxConnectorRestarts:   1,
+			ConnectorRestartPeriod: defaultRestartPeriod,
+			MaxTaskRestarts:        1,
+			TaskRestartPeriod:      defaultRestartPeriod,
+		}
+	}
+
+	// apply overrides
+	if overrides != nil {
+		for k, v := range overrides.Connectors {
+			p := policy[k]
+
+			if v.MaxConnectorRestarts != 0 {
+				p.MaxConnectorRestarts = v.MaxConnectorRestarts
+			}
+			if v.ConnectorRestartPeriod != 0 {
+				p.ConnectorRestartPeriod = v.ConnectorRestartPeriod
+			}
+			if v.MaxTaskRestarts != 0 {
+				p.MaxTaskRestarts = v.MaxTaskRestarts
+			}
+			if v.TaskRestartPeriod != 0 {
+				p.TaskRestartPeriod = v.TaskRestartPeriod
+			}
+
+			policy[k] = p
+		}
+	}
+	return policy
+}

--- a/pkg/manager/restart_policy.go
+++ b/pkg/manager/restart_policy.go
@@ -15,7 +15,7 @@ const (
 )
 
 func runtimePolicyFromConnectors(connectors []connect.Connector, overrides *RestartPolicy) runtimeRestartPolicy {
-	// create dynamic restart policy here, overriding with any supplied values (if any)
+	// create restart policy here, overriding with any supplied values (if any)
 	policy := runtimeRestartPolicy{}
 
 	for _, c := range connectors {

--- a/pkg/manager/restart_policy_test.go
+++ b/pkg/manager/restart_policy_test.go
@@ -1,0 +1,61 @@
+package manager
+
+import (
+	"testing"
+	"time"
+
+	"github.com/90poe/connectctl/pkg/client/connect"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_RestartPolicy_Default(t *testing.T) {
+	t.Parallel()
+
+	connectors := []connect.Connector{
+		connect.Connector{Name: "foo"},
+	}
+
+	policy := runtimePolicyFromConnectors(connectors, nil)
+
+	require.Len(t, policy, 1)
+	require.NotNil(t, policy["foo"])
+
+	foo := policy["foo"]
+
+	require.Equal(t, 1, foo.MaxConnectorRestarts)
+	require.Equal(t, 1, foo.MaxTaskRestarts)
+	require.Equal(t, defaultRestartPeriod, foo.ConnectorRestartPeriod)
+	require.Equal(t, defaultRestartPeriod, foo.TaskRestartPeriod)
+}
+
+func Test_RestartPolicy_Override(t *testing.T) {
+	t.Parallel()
+
+	connectors := []connect.Connector{
+		connect.Connector{Name: "foo"},
+	}
+
+	ovveride := RestartPolicy{
+		Connectors: map[string]Policy{
+			"foo": Policy{
+				MaxConnectorRestarts:   10,
+				MaxTaskRestarts:        11,
+				TaskRestartPeriod:      time.Second * 100,
+				ConnectorRestartPeriod: time.Second * 101,
+			},
+		},
+	}
+
+	policy := runtimePolicyFromConnectors(connectors, &ovveride)
+
+	require.Len(t, policy, 1)
+	require.NotNil(t, policy["foo"])
+
+	foo := policy["foo"]
+
+	require.Equal(t, 10, foo.MaxConnectorRestarts)
+	require.Equal(t, 11, foo.MaxTaskRestarts)
+	require.Equal(t, time.Second*101, foo.ConnectorRestartPeriod)
+	require.Equal(t, time.Second*100, foo.TaskRestartPeriod)
+}

--- a/pkg/manager/tasks.go
+++ b/pkg/manager/tasks.go
@@ -13,12 +13,12 @@ type TaskPredicate func(connect.TaskState) bool
 
 // IsRunning returns true if the connector task is in a RUNNING state
 func IsRunning(task connect.TaskState) bool {
-	return task.State == "RUNNING"
+	return task.State == "RUNNING" //nolint
 }
 
 // IsNotRunning returns true if the connector task is not in a RUNNING state
 func IsNotRunning(task connect.TaskState) bool {
-	return task.State != "RUNNING"
+	return task.State != "RUNNING" //nolint
 }
 
 // ByID returns a predicate that returns true if the connector task has one of the given task IDs


### PR DESCRIPTION
This PR adds functionality to implement a restart policy for connectors and/or tasks.

If `connectclt connectors manage` is run with the `--auto-restart` option we create the following policy for each configured connector
- MaxConnectorRestarts - 1
- MaxTaskRestarts - 1
- ConnectorRestartPeriod - 10seconds
- TaskRestartPeriod - 10 seconds

When the connector/task is restarted we attempt to reset the counter of attempts to 0 so the next time it fails it will be restarted again as per the policy.

After attempting to restart the connector connectctl waits the restart period before querying its status.

There is no current way to set a policy - this will be added in a later PR.